### PR TITLE
Add Gradle platform BOM for version alignment

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,14 +1,13 @@
 plugins {
-  `java-platform`
   id("org.springframework.boot") version "3.3.1" apply false
   id("io.spring.dependency-management") version "1.1.5" apply false
   kotlin("jvm") version "1.9.24" apply false // if using kotlin
 }
 
-javaPlatform.allowDependencies()
-
 subprojects {
-  apply(plugin = "java-library")
+  if (name != "platform-bom") {
+    apply(plugin = "java-library")
+  }
   repositories {
     mavenCentral()
   }

--- a/backend/event-store/build.gradle.kts
+++ b/backend/event-store/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins { `java-library` }
 
 dependencies {
+  api(platform(project(":platform-bom")))
   api(project(":shared-kernel"))
   implementation("org.springframework:spring-jdbc")
   implementation("org.postgresql:postgresql")

--- a/backend/modules/client-profile/build.gradle.kts
+++ b/backend/modules/client-profile/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
 }
 
 dependencies {
+  api(platform(project(":platform-bom")))
   api(project(":shared-kernel"))
   api(project(":event-store"))
   implementation("org.springframework.boot:spring-boot-starter-validation")

--- a/backend/platform-bom/build.gradle.kts
+++ b/backend/platform-bom/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+    `java-platform`
+}
+
+javaPlatform {
+    allowDependencies()
+}
+
+val springBootVersion = "3.3.1"
+val jacksonVersion = "2.17.1"
+val postgresVersion = "42.7.3"
+val junitJupiterVersion = "5.10.2"
+
+dependencies {
+    constraints {
+        api("org.springframework.boot:spring-boot-starter-validation:$springBootVersion")
+        api("org.springframework.boot:spring-boot-starter-json:$springBootVersion")
+        api("org.springframework:spring-context:6.1.6")
+        api("org.springframework:spring-jdbc:6.1.6")
+        api("com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion")
+        api("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
+        api("org.postgresql:postgresql:$postgresVersion")
+        api("org.junit.jupiter:junit-jupiter:$junitJupiterVersion")
+    }
+}
+

--- a/backend/shared-kernel/build.gradle.kts
+++ b/backend/shared-kernel/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins { `java-library` }
 
 dependencies {
+  api(platform(project(":platform-bom")))
   api("org.springframework:spring-context")
   api("com.fasterxml.jackson.core:jackson-annotations")
 }


### PR DESCRIPTION
## Summary
- add dedicated `platform-bom` project that defines dependency versions
- remove `java-platform` from root build
- apply BOM to `shared-kernel`, `event-store`, and `client-profile`

## Testing
- `./gradlew test` *(fails: Unable to download Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68812548812883249ea7981236110c37